### PR TITLE
Prevent blank shortcuts

### DIFF
--- a/app/main/server/app/ui/pref-window.js
+++ b/app/main/server/app/ui/pref-window.js
@@ -2,6 +2,7 @@
 
 const electron = require('electron');
 const shell = electron.shell;
+const dialog = electron.dialog;
 const BrowserWindow = electron.BrowserWindow;
 const windowUtil = require('./window-util');
 const RpcChannel = require('../../../shared/rpc-channel');
@@ -47,9 +48,14 @@ module.exports = class PrefWindow {
       show: false
     });
     this.browserWindow.loadURL(url);
-    this.browserWindow.on('close', () => {
-      this.prefManager.commitPreferences();
-      this.browserWindow = null;
+    this.browserWindow.on('close', (evt) => {
+      if (!this.prefManager.verifyPreferences()) {
+        dialog.showErrorBox('Hain', 'Invalid shortcut.');
+        evt.preventDefault();
+      } else {
+        this.prefManager.commitPreferences();
+        this.browserWindow = null;
+      }
     });
 
     this.browserWindow.webContents.on('will-navigate', (evt, _url) => {

--- a/app/main/server/preferences/pref-manager.js
+++ b/app/main/server/preferences/pref-manager.js
@@ -42,6 +42,9 @@ module.exports = class PrefManager {
     }
     this.workerProxy.resetPreferences(prefId);
   }
+  verifyPreferences() {
+    return this.appPref.isValidShortcut;
+  }
   commitPreferences() {
     this.workerProxy.commitPreferences();
 

--- a/app/main/shared/preferences-object.js
+++ b/app/main/shared/preferences-object.js
@@ -23,6 +23,7 @@ class PreferencesObject extends EventEmitter {
 
     this.model = {};
     this._isDirty = false;
+    this._isValidShortcut = true;
     this.encoderOptions = {
       encryptionKey: makeEncryptionKey(id)
     };
@@ -31,6 +32,9 @@ class PreferencesObject extends EventEmitter {
   }
   get isDirty() {
     return this._isDirty;
+  }
+  get isValidShortcut() {
+    return this._isValidShortcut;
   }
   load() {
     const defaults = schemaDefaults(this.schema);
@@ -53,10 +57,23 @@ class PreferencesObject extends EventEmitter {
     return defaults;
   }
   update(model) {
-    if (lo_isEqual(this.model, model))
+    if (lo_isEqual(this.model, model) || !this.verify(model))
       return;
     this.model = model;
     this._isDirty = true;
+  }
+  verify(model) {
+    this._isValidShortcut = true;
+    if (model && model.customQueryShortcuts && model.customQueryShortcuts.length > 0) {
+      model.customQueryShortcuts.forEach((entry) => {
+        Object.keys(entry).forEach((key) => {
+          if (entry[key] === '') {
+            this._isValidShortcut = false;
+          }
+        });
+      });
+    }
+    return this._isValidShortcut;
   }
   toPrefFormat() {
     return {


### PR DESCRIPTION
In the Preferences window, we can register blanks as Custom Query Shortcuts.
This Pull Request prevents them, and notice "Invalid shortcut" when entries include blanks.