### PR TITLE
Fix plugin manager spinning endlessly (Issue #234)

### DIFF
--- a/app/main/plugins/hain-package-manager/downloads-count.js
+++ b/app/main/plugins/hain-package-manager/downloads-count.js
@@ -2,8 +2,12 @@
 
 const lo_assign = require('lodash.assign');
 const got = require('got');
+const moment = require('moment');
 
-const RANGE_ALL = '1000-01-01:3000-01-01';
+const now = moment();
+const RANGE_START = now.subtract(364, 'days').format('YYYY-MM-DD');
+const RANGE_END = now.format('YYYY-MM-DD');
+const RANGE_ALL = `${RANGE_START}:${RANGE_END}`;
 const PERIOD_LAST_MONTH = 'last-month';
 
 function _getDownloadCountForPoint(packages, period) {
@@ -19,10 +23,24 @@ function _getDownloadCountForRange(packages, range) {
   const baseUrl = `http://api.npmjs.org/downloads/range/${range}/${query_enc},`
   return got(baseUrl, { json: true }).then(res => {
     const { body } = res;
+    const result = {};
     Object.keys(body).forEach(pkg => {
-      body[pkg].downloads = body[pkg].downloads.reduce((sum, dl) => sum + dl.downloads, 0);
+      // skip empty keys
+      if (!pkg) return;
+
+      result[pkg] = {
+        package: pkg,
+        start: body[pkg].start,
+        end: body[pkg].end,
+        downloads: 0, // initialize to zero
+      };
+
+      if (body[pkg].downloads) {
+        // update downloads if there are downloads
+        result[pkg].downloads = body[pkg].downloads.reduce((sum, dl) => sum + dl.downloads, 0);
+      }
     });
-    return body;
+    return result;
   });
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -47,6 +47,7 @@
     "lodash.uniq": "^4.2.1",
     "material-ui": "0.15.0-alpha.2",
     "mathjs": "^3.0.0",
+    "moment": "^2.18.1",
     "node-persist": "0.0.10",
     "plist": "2.0.1",
     "react": "^0.14.7",


### PR DESCRIPTION
There was an error about trying to pull too large of a range, exceeding 365 days, so the range has been limited to the past year as of the current time of the query.

Additionally, there were issues with the results containing a blank key in the response object or there were no downloads key with the download data per day which was causing problems.
