### PR TITLE
Plugin: filesearch optimisations / robustness

### DIFF
--- a/app/main/plugins/hain-plugin-filesearch/darwin/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/darwin/index.js
@@ -14,7 +14,13 @@ module.exports = (context) => {
   const indexer = context.indexer;
   const toast = context.toast;
 
-  const recursiveSearchDirs = sharedUtil.injectEnvVariables(initialPref.recursiveFolders || []);
+  let recursiveSearchDirs = [];
+  try {
+    recursiveSearchDirs = sharedUtil.injectEnvVariables(initialPref.recursiveFolders || []);
+  } catch (err) {
+    logger.log(err.message);
+  }
+
   const lazyIndexingKeys = {};
 
   function* findFilesAndUpdateIndexer(dirs, recursive) {
@@ -63,12 +69,19 @@ module.exports = (context) => {
   function* setupWatchers(dirs, recursive) {
     for (const dir of dirs) {
       const _dir = dir;
-      fs.watch(_dir, {
-        persistent: true,
-        recursive: recursive
-      }, (evt, filename) => {
-        lazyRefreshIndex(_dir, recursive);
-      });
+
+      try {
+        fs.watch(_dir, {
+          persistent: true,
+          recursive: recursive
+        }, (evt, filename) => {
+          lazyRefreshIndex(_dir, recursive);
+        });
+
+      } catch (err) {
+        logger.log(err);
+        logger.log(err.stack);
+      }
     }
   }
 

--- a/app/main/plugins/hain-plugin-filesearch/darwin/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/darwin/index.js
@@ -97,7 +97,7 @@ module.exports = (context) => {
 
   function execute(id, payload, extra) {
     if (fs.existsSync(id) === false) {
-      toast.enqueue('Sorry, Could\'nt Find a File');
+      toast.enqueue('Sorry, Couldn\'t Find a File');
       return;
     }
 

--- a/app/main/plugins/hain-plugin-filesearch/shared-util.js
+++ b/app/main/plugins/hain-plugin-filesearch/shared-util.js
@@ -14,10 +14,21 @@ function injectEnvVariable(dirPath) {
   }
 
   // Inject Environment Variables
-  for (const envVar in process.env) {
-    const value = process.env[envVar];
-    _path = _path.replace(`\${${envVar}}`, value);
+  let tokens = dirPath.match(/\${.*?}/g);
+
+  if (tokens) {
+    for (const i in tokens) {
+      const tokenId = tokens[i].slice(2, -1);
+      const value = process.env[tokenId];
+
+      if (value === undefined) {
+        throw new Error(`can't translate provided token ${tokens[i]} into a valid environment variable`);
+      }
+
+      _path = _path.replace(tokens[i], value);
+    }
   }
+
   return _path;
 }
 

--- a/app/main/plugins/hain-plugin-filesearch/win32/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/win32/index.js
@@ -104,7 +104,7 @@ module.exports = (context) => {
 
   function execute(id, payload, extra) {
     if (fs.existsSync(id) === false) {
-      toast.enqueue('Sorry, Could\'nt Find a File');
+      toast.enqueue('Sorry, Couldn\'t Find a File');
       return;
     }
 

--- a/app/main/plugins/hain-plugin-filesearch/win32/index.js
+++ b/app/main/plugins/hain-plugin-filesearch/win32/index.js
@@ -16,8 +16,20 @@ module.exports = (context) => {
   const indexer = context.indexer;
   const toast = context.toast;
 
-  const recursiveSearchDirs = sharedUtil.injectEnvVariables(initialPref.recursiveFolders || []);
-  const flatSearchDirs = sharedUtil.injectEnvVariables(initialPref.flatFolders || []);
+  let recursiveSearchDirs = [];
+  try {
+    recursiveSearchDirs = sharedUtil.injectEnvVariables(initialPref.recursiveFolders || []);
+  } catch (err) {
+    logger.log(err.message);
+  }
+
+  let flatSearchDirs = [];
+  try {
+    flatSearchDirs = sharedUtil.injectEnvVariables(initialPref.flatFolders || []);
+  } catch (err) {
+    logger.log(err.message);
+  }
+
   const searchExtensions = initialPref.searchExtensions || [];
 
   const lazyIndexingKeys = {};
@@ -62,12 +74,19 @@ module.exports = (context) => {
   function* setupWatchers(dirs, recursive) {
     for (const dir of dirs) {
       const _dir = dir;
-      fs.watch(_dir, {
-        persistent: true,
-        recursive: recursive
-      }, (evt, filename) => {
-        lazyRefreshIndex(_dir, recursive);
-      });
+
+      try {
+        fs.watch(_dir, {
+          persistent: true,
+          recursive: recursive
+        }, (evt, filename) => {
+          lazyRefreshIndex(_dir, recursive);
+        });
+
+      } catch (err) {
+        logger.log(err);
+        logger.log(err.stack);
+      }
     }
   }
 


### PR DESCRIPTION
* Switch to an alternate strategy for replacing environment variables.
  - Currently, for each path that we wanted to replace a token in, the injector would loop through *all* of the available environment variables - this could be 10s/100s of items per path entry.
  - Now, I extract the exact tokens out of the path entry, and attempt a replacement of each token. This also allows the more robust handling described below.

**This results in a 10x/20x speedup on this startup process (from 30ms down to 1/0.5ms)!**

* Add robustness to environment variable injection:
  - When an invalid token is defined in the scanned paths (eg. "${MYINVALIDTOKEN}\\Desktop")
  - When the translated path cannot be read (eg. "C:\ThisDirectoryDoesNotExist")